### PR TITLE
Zero-click mode: auto-fetch customs and launch Synth Riders

### DIFF
--- a/Assets/Prefabs/MainCanvas.prefab
+++ b/Assets/Prefabs/MainCanvas.prefab
@@ -110,7 +110,7 @@ RectTransform:
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: -0.0000074804, y: 0}
-  m_SizeDelta: {x: 18.248, y: 2.9793}
+  m_SizeDelta: {x: 14.5, y: 3.6}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &1140782431598852251
 CanvasRenderer:
@@ -170,9 +170,9 @@ MonoBehaviour:
   m_fontSize: 1.6
   m_fontSizeBase: 1.6
   m_fontWeight: 400
-  m_enableAutoSizing: 0
-  m_fontSizeMin: 6
-  m_fontSizeMax: 18
+  m_enableAutoSizing: 1
+  m_fontSizeMin: 0.85
+  m_fontSizeMax: 1.45
   m_fontStyle: 0
   m_HorizontalAlignment: 2
   m_VerticalAlignment: 512
@@ -695,6 +695,7 @@ RectTransform:
   - {fileID: 7614165235135417095}
   - {fileID: 8788036221854437377}
   - {fileID: 672229581221611754}
+  - {fileID: 8800111222333444556}
   - {fileID: 767608775763727094}
   m_Father: {fileID: 8999204219072832006}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -2934,9 +2935,9 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 3811221993635812278}
-        m_TargetAssemblyTypeName: SynthLauncher, Assembly-CSharp
-        m_MethodName: LaunchSynthRiders
+      - m_Target: {fileID: 5429377102869206265}
+        m_TargetAssemblyTypeName: DownloadManager, Assembly-CSharp
+        m_MethodName: OnLaunchSynthRidersButtonClicked
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -3424,6 +3425,8 @@ MonoBehaviour:
   DownloadFilters: {fileID: 9218390427614116185}
   FixTimestampsButton: {fileID: 1764527938192308165}
   MoveDownloadsButton: {fileID: 8528566793730894595}
+  LaunchSynthRidersButton: {fileID: 5637596291254037384}
+  LaunchSynthRidersButtonText: {fileID: 8581815265903506025}
   logger: {fileID: 0}
 --- !u!114 &3811221993635812278
 MonoBehaviour:
@@ -3468,6 +3471,8 @@ MonoBehaviour:
   logger: {fileID: 0}
   customFileManager: {fileID: 287202588508738705}
   downloadFilters: {fileID: 9218390427614116185}
+  synthLauncher: {fileID: 3811221993635812278}
+  zeroClickModeToggle: {fileID: 8800111222333444558}
 --- !u!1 &7233226911408624794
 GameObject:
   m_ObjectHideFlags: 0
@@ -4461,6 +4466,291 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &8800111222333444555
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8800111222333444556}
+  - component: {fileID: 8800111222333444557}
+  - component: {fileID: 8800111222333444570}
+  - component: {fileID: 8800111222333444558}
+  - component: {fileID: 8800111222333444559}
+  m_Layer: 0
+  m_Name: btnZeroClickMode
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8800111222333444556
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8800111222333444555}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 8800111222333444661}
+  m_Father: {fileID: 7510676949469706641}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0}
+  m_AnchorMax: {x: 0.5, y: 0}
+  m_AnchoredPosition: {x: 0.258, y: 0.17199999}
+  m_SizeDelta: {x: 0.50, y: 0.2044}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &8800111222333444557
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8800111222333444555}
+  m_CullTransparentMesh: 1
+--- !u!114 &8800111222333444570
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8800111222333444555}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 2ddaba5f3188c1b428a8b04c667b3691, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &8800111222333444558
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8800111222333444555}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a7c3e91f4b2d8e6479f0a1c5e6d83b42, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Label: {fileID: 8800111222333444663}
+  logger: {fileID: 0}
+  downloadManager: {fileID: 5429377102869206265}
+--- !u!114 &8800111222333444559
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8800111222333444555}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.019607825, g: 0.5022908, b: 0.78431374, a: 1}
+    m_PressedColor: {r: 1, g: 0, b: 0, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 8800111222333444570}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 8800111222333444558}
+        m_TargetAssemblyTypeName: ZeroClickModeToggle, Assembly-CSharp
+        m_MethodName: Toggle
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!1 &8800111222333444660
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8800111222333444661}
+  - component: {fileID: 8800111222333444662}
+  - component: {fileID: 8800111222333444663}
+  m_Layer: 0
+  m_Name: text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8800111222333444661
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8800111222333444660}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.049999997, y: 0.049999997, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8800111222333444556}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0.0011}
+  m_SizeDelta: {x: 7.2, y: 2.9793}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &8800111222333444662
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8800111222333444660}
+  m_CullTransparentMesh: 1
+--- !u!114 &8800111222333444663
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8800111222333444660}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: '0-Click: OFF'
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 1.6
+  m_fontSizeBase: 1.6
+  m_fontWeight: 400
+  m_enableAutoSizing: 1
+  m_fontSizeMin: 1
+  m_fontSizeMax: 1.6
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 1
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
 --- !u!1001 &7904860373862094390
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -4517,7 +4807,7 @@ PrefabInstance:
     - target: {fileID: 7427751615383340224, guid: b7b4f57afddb1c64090da61664d97773,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 0.72855
+      value: 0.22
       objectReference: {fileID: 0}
     - target: {fileID: 7427751615383340224, guid: b7b4f57afddb1c64090da61664d97773,
         type: 3}
@@ -4562,7 +4852,7 @@ PrefabInstance:
     - target: {fileID: 7427751615383340224, guid: b7b4f57afddb1c64090da61664d97773,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0.39342
+      value: 0.648
       objectReference: {fileID: 0}
     - target: {fileID: 7427751615383340224, guid: b7b4f57afddb1c64090da61664d97773,
         type: 3}

--- a/Assets/Scripts/DisplayManager.cs
+++ b/Assets/Scripts/DisplayManager.cs
@@ -16,7 +16,11 @@ public class DisplayManager : MonoBehaviour
     public DownloadFilters DownloadFilters;
     public Button FixTimestampsButton;
     public Button MoveDownloadsButton;
+    public Button LaunchSynthRidersButton;
+    public TextMeshProUGUI LaunchSynthRidersButtonText;
     public SRLogHandler logger;
+
+    public const string LaunchSynthRidersLabel = "Play Synth Riders";
 
     private void Awake()
     {
@@ -62,5 +66,56 @@ public class DisplayManager : MonoBehaviour
         FetchMapsButton.interactable = true;
         FetchMapsButtonText.fontStyle = FontStyles.Normal;
         UpdateFilterText();
+        ResetLaunchSynthRidersButton();
+    }
+
+    public void ShowZeroClickFetchInProgress() {
+        FixTimestampsButton.interactable = false;
+        MoveDownloadsButton.interactable = false;
+        FetchMapsButton.interactable = false;
+        FetchMapsButtonText.fontStyle = FontStyles.Italic;
+        FetchMapsButtonText.SetText("Checking for new customs...");
+        ResetLaunchSynthRidersButton();
+    }
+
+    public void ShowZeroClickFetchResult(int newMapsFound) {
+        FixTimestampsButton.interactable = false;
+        MoveDownloadsButton.interactable = false;
+        FetchMapsButton.interactable = false;
+        FetchMapsButtonText.fontStyle = FontStyles.Normal;
+        FetchMapsButtonText.SetText(FormatNewCustomsFoundText(newMapsFound));
+    }
+
+    public void ShowLaunchCountdown(int secondsRemaining) {
+        FixTimestampsButton.interactable = false;
+        MoveDownloadsButton.interactable = false;
+
+        if (LaunchSynthRidersButton == null || LaunchSynthRidersButtonText == null)
+        {
+            logger?.ErrorLog("Launch Synth Riders button references are missing; countdown UI cannot update.");
+            return;
+        }
+
+        LaunchSynthRidersButton.interactable = true;
+        LaunchSynthRidersButtonText.fontStyle = FontStyles.Italic;
+        LaunchSynthRidersButtonText.enableWordWrapping = true;
+        LaunchSynthRidersButtonText.SetText($"Synthing: {secondsRemaining}\nTap to stay");
+    }
+
+    private static string FormatNewCustomsFoundText(int newMapsFound) {
+        return newMapsFound == 1 ? "1 new custom found" : $"{newMapsFound} new customs found";
+    }
+
+    public void ResetLaunchSynthRidersButton() {
+        if (LaunchSynthRidersButton != null)
+        {
+            LaunchSynthRidersButton.interactable = true;
+        }
+
+        if (LaunchSynthRidersButtonText != null)
+        {
+            LaunchSynthRidersButtonText.fontStyle = FontStyles.Normal;
+            LaunchSynthRidersButtonText.SetText(LaunchSynthRidersLabel);
+        }
     }
 }

--- a/Assets/Scripts/DownloadManager.cs
+++ b/Assets/Scripts/DownloadManager.cs
@@ -15,12 +15,19 @@ public class DownloadManager : MonoBehaviour
     public SRLogHandler logger;
     public CustomFileManagerBehaviour customFileManager;
     public DownloadFilters downloadFilters;
+    public SynthLauncher synthLauncher;
+    public ZeroClickModeToggle zeroClickModeToggle;
 
     public bool UseZ = true;
     public bool UseSyn = true;
     public bool UseMagnet = true;
 
+    public const int ZeroClickCountdownSeconds = 5;
+
     private bool _isDownloading = false;
+    private bool _cancelZeroClickFlow = false;
+    private bool _launchCountdownActive = false;
+    private bool _zeroClickFlowInProgress = false;
     private MapRepo _customMapRepo;
     private DownloadManagerZ _downloadManagerZ;
     private DownloadManagerSyn _downloadManagerSyn;
@@ -34,42 +41,83 @@ public class DownloadManager : MonoBehaviour
 
     private async void OnEnable()
     {
-        displayManager.DisableActions("Initializing maps source...");
+        if (_zeroClickFlowInProgress)
+        {
+            logger.DebugLog("Zero-click flow already running; skipping duplicate OnEnable.");
+            return;
+        }
+
+        var zeroClickRequested = ZeroClickModeToggle.ShouldRunZeroClickFlow();
+        displayManager.DisableActions(zeroClickRequested ? "Checking for new customs..." : "Initializing maps source...");
 
         await _customMapRepo.Initialize();
-        
+
+        zeroClickModeToggle?.RefreshAvailability();
+
+        if (ZeroClickModeToggle.ShouldRunZeroClickFlow())
+        {
+            _zeroClickFlowInProgress = true;
+            try
+            {
+                await RunZeroClickFlowAsync();
+            }
+            finally
+            {
+                _zeroClickFlowInProgress = false;
+            }
+            return;
+        }
+
         displayManager.EnableActions();
     }
 
     public void StartDownloading() => _ = StartDownloadingAsync();
-    
-    public async Task StartDownloadingAsync()
+
+    public async Task<bool> StartDownloadingAsync(bool useLastFetchCutoffOnly = false, bool suppressEnableActions = false)
     {
         if (_isDownloading)
         {
             logger.DebugLog("Already downloading!");
-            return;
+            return false;
         }
 
         _isDownloading = true;
-        displayManager.DisableActions("Downloading...");
+
+        if (!suppressEnableActions)
+        {
+            displayManager.DisableActions("Downloading...");
+        }
+        else
+        {
+            displayManager.DisableActions("Checking for new customs...");
+        }
+
+        var success = false;
 
         try
         {
             var nowUtc = DateTime.UtcNow;
-            var cutoffTimeUtc = downloadFilters.GetDateCutoffFromCurrentSelection(nowUtc);
+            var cutoffTimeUtc = useLastFetchCutoffOnly
+                ? Preferences.GetLastDownloadedTime()
+                : downloadFilters.GetDateCutoffFromCurrentSelection(nowUtc);
             logger.DebugLog($"Using cutoff time (local) {cutoffTimeUtc.ToLocalTime()}");
-            
-            // TODO get difficulty info somewhere. For now, use all difficulties
+
             var difficultySelections = downloadFilters.GetDifficultiesEnabled();
             logger.DebugLog("Using difficulties " + String.Join(",", difficultySelections));
 
-            bool success = await _customMapRepo.TryDownloadWithFallbacks(cutoffTimeUtc, difficultySelections, Application.exitCancellationToken);
+            success = await _customMapRepo.TryDownloadWithFallbacks(cutoffTimeUtc, difficultySelections, Application.exitCancellationToken);
             if (success)
             {
                 Preferences.SetLastDownloadedTime(nowUtc);
+                Preferences.MarkInitialFetchCompleted();
                 customFileManager.SetLastDownloadedTime(nowUtc);
                 displayManager.UpdateLastFetchTime();
+                zeroClickModeToggle?.RefreshAvailability();
+
+                if (suppressEnableActions)
+                {
+                    displayManager.ShowZeroClickFetchResult(_customMapRepo.LastNewMapsFound);
+                }
             }
         }
         catch (Exception e)
@@ -81,7 +129,119 @@ public class DownloadManager : MonoBehaviour
 
         _isDownloading = false;
 
-        displayManager.EnableActions();
+        if (!suppressEnableActions)
+        {
+            displayManager.EnableActions();
+        }
+
+        return success;
+    }
+
+    public void CancelPendingZeroClickFlow()
+    {
+        _cancelZeroClickFlow = true;
+        logger.DebugLog("Zero-click auto-launch cancelled by user.");
+    }
+
+    public void OnLaunchSynthRidersButtonClicked()
+    {
+        if (_launchCountdownActive)
+        {
+            CancelPendingZeroClickFlow();
+            _launchCountdownActive = false;
+            displayManager.ResetLaunchSynthRidersButton();
+            displayManager.EnableActions();
+            return;
+        }
+
+        synthLauncher?.LaunchSynthRiders();
+    }
+
+    private async Task RunZeroClickFlowAsync()
+    {
+        logger.DebugLog("Zero-click phase 1/3: fetching new customs since last fetch...");
+
+        var fetchSucceeded = await RunZeroClickFetchAsync();
+        if (!ZeroClickModeToggle.ShouldRunZeroClickFlow())
+        {
+            logger.DebugLog("Zero-click mode disabled during fetch; staying in app.");
+            displayManager.EnableActions();
+            return;
+        }
+
+        if (!fetchSucceeded)
+        {
+            logger.ErrorLog("Zero-click mode: fetch failed; staying in app for manual retry.");
+            displayManager.EnableActions();
+            return;
+        }
+
+        logger.DebugLog("Zero-click phase 2/3: fetch complete; starting launch countdown.");
+        if (!await WaitForLaunchCountdownAsync())
+        {
+            logger.DebugLog("Zero-click auto-launch cancelled; staying in app.");
+            displayManager.EnableActions();
+            return;
+        }
+
+        logger.DebugLog("Zero-click phase 3/3: launching Synth Riders...");
+        if (synthLauncher != null)
+        {
+            synthLauncher.LaunchSynthRiders();
+        }
+        else
+        {
+            logger.ErrorLog("Zero-click mode: SynthLauncher reference missing!");
+            displayManager.EnableActions();
+        }
+    }
+
+    private async Task<bool> RunZeroClickFetchAsync()
+    {
+        while (_isDownloading)
+        {
+            await Task.Delay(100, Application.exitCancellationToken);
+        }
+
+        displayManager.ShowZeroClickFetchInProgress();
+        return await StartDownloadingAsync(useLastFetchCutoffOnly: true, suppressEnableActions: true);
+    }
+
+    private async Task<bool> WaitForLaunchCountdownAsync()
+    {
+        _cancelZeroClickFlow = false;
+        _launchCountdownActive = true;
+        zeroClickModeToggle?.SetInteractable(true);
+
+        try
+        {
+            for (var secondsRemaining = ZeroClickCountdownSeconds; secondsRemaining >= 1; secondsRemaining--)
+            {
+                if (_cancelZeroClickFlow || !ZeroClickModeToggle.ShouldRunZeroClickFlow())
+                {
+                    return false;
+                }
+
+                displayManager.ShowLaunchCountdown(secondsRemaining);
+                await Task.Delay(1000, Application.exitCancellationToken);
+            }
+
+            return !_cancelZeroClickFlow && ZeroClickModeToggle.ShouldRunZeroClickFlow();
+        }
+        catch (OperationCanceledException)
+        {
+            return false;
+        }
+        finally
+        {
+            _launchCountdownActive = false;
+            zeroClickModeToggle?.SetInteractable(true);
+
+            if (_cancelZeroClickFlow || !ZeroClickModeToggle.ShouldRunZeroClickFlow())
+            {
+                displayManager.ResetLaunchSynthRidersButton();
+            }
+        }
     }
 
     /// <summary>

--- a/Assets/Scripts/Preferences.cs
+++ b/Assets/Scripts/Preferences.cs
@@ -8,6 +8,8 @@ public class Preferences {
     private static string KEY_LAST_DOWNLOADED_TIME_SEC = "lastDownloadedTimeSec";
     public static int DEFAULT_LAST_DOWNLOADED_TIME_SEC = 0;
     private static string KEY_SELECTED_DIFFICULTIES = "selectedDifficulties";
+    private static string KEY_HAS_COMPLETED_INITIAL_FETCH = "hasCompletedInitialFetch";
+    private static string KEY_ZERO_CLICK_MODE = "zeroClickMode";
 
     public static void SetLastDownloadedTime(DateTime lastDownloadedTime) {
         DateTimeOffset dto = lastDownloadedTime;
@@ -30,5 +32,31 @@ public class Preferences {
         // Default to all difficulties
         var csvDifficulties = PlayerPrefs.GetString(KEY_SELECTED_DIFFICULTIES, "Easy,Normal,Hard,Expert,Master,Custom");
         return csvDifficulties.Split(",", StringSplitOptions.RemoveEmptyEntries).ToHashSet();
+    }
+
+    /// <summary>
+    /// True after the user completes at least one successful fetch. Unlocks zero-click mode.
+    /// Existing installs with a prior fetch timestamp also qualify.
+    /// </summary>
+    public static bool HasCompletedInitialFetch() {
+        if (PlayerPrefs.GetInt(KEY_HAS_COMPLETED_INITIAL_FETCH, 0) == 1) {
+            return true;
+        }
+
+        return GetLastDownloadedTime() > DateTime.UnixEpoch;
+    }
+
+    public static void MarkInitialFetchCompleted() {
+        PlayerPrefs.SetInt(KEY_HAS_COMPLETED_INITIAL_FETCH, 1);
+        PlayerPrefs.Save();
+    }
+
+    public static bool GetZeroClickMode() {
+        return HasCompletedInitialFetch() && PlayerPrefs.GetInt(KEY_ZERO_CLICK_MODE, 0) == 1;
+    }
+
+    public static void SetZeroClickMode(bool enabled) {
+        PlayerPrefs.SetInt(KEY_ZERO_CLICK_MODE, enabled ? 1 : 0);
+        PlayerPrefs.Save();
     }
 }

--- a/Assets/Scripts/ZeroClickModeToggle.cs
+++ b/Assets/Scripts/ZeroClickModeToggle.cs
@@ -1,0 +1,90 @@
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+
+/// <summary>
+/// Optional zero-click mode: after the user completes one manual fetch, they can enable
+/// auto-fetch-on-launch followed by launching Synth Riders with no in-app interaction.
+/// </summary>
+public class ZeroClickModeToggle : MonoBehaviour
+{
+    public TextMeshProUGUI Label;
+    public SRLogHandler logger;
+    public DownloadManager downloadManager;
+
+    private bool _isEnabled;
+    private Button _button;
+
+    private void Awake()
+    {
+        _button = GetComponent<Button>();
+    }
+
+    private void OnEnable()
+    {
+        RefreshAvailability();
+    }
+
+    public void SetInteractable(bool interactable)
+    {
+        if (_button != null)
+        {
+            _button.interactable = interactable;
+        }
+    }
+
+    public void RefreshAvailability()
+    {
+        bool available = Preferences.HasCompletedInitialFetch();
+        gameObject.SetActive(available);
+
+        if (!available)
+        {
+            Preferences.SetZeroClickMode(false);
+            return;
+        }
+
+        SetEnabled(Preferences.GetZeroClickMode(), save: false);
+    }
+
+    public void Toggle()
+    {
+        if (!Preferences.HasCompletedInitialFetch())
+        {
+            return;
+        }
+
+        var enabling = !_isEnabled;
+        SetEnabled(enabling, save: true);
+
+        if (!enabling)
+        {
+            downloadManager?.CancelPendingZeroClickFlow();
+        }
+    }
+
+    private void SetEnabled(bool enabled, bool save)
+    {
+        _isEnabled = enabled;
+
+        if (save)
+        {
+            Preferences.SetZeroClickMode(enabled);
+            logger?.DebugLog($"Zero-click mode {(enabled ? "enabled" : "disabled")}");
+        }
+
+        if (Label == null)
+        {
+            return;
+        }
+
+        Label.fontStyle = enabled ? FontStyles.Underline : FontStyles.Normal;
+        Label.color = enabled ? Color.white : Color.gray;
+        Label.SetText(enabled ? "0-Click: ON" : "0-Click: OFF");
+    }
+
+    public static bool ShouldRunZeroClickFlow()
+    {
+        return Preferences.HasCompletedInitialFetch() && Preferences.GetZeroClickMode();
+    }
+}

--- a/Assets/Scripts/ZeroClickModeToggle.cs.meta
+++ b/Assets/Scripts/ZeroClickModeToggle.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a7c3e91f4b2d8e6479f0a1c5e6d83b42
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,16 @@ Note - you may need to reimport songs in Synth Riders after applying this fix, t
 ## Play Synth Riders
 Closes this application and launches the Synth Riders application. I haven't tested what happens if Synth Riders isn't installed, but I doubt that'll be a common problem :P
 
+## Zero-Click Mode
+After you complete at least one successful **Fetch All/Filtered**, a **Zero-Click Mode** toggle appears on the main panel.
+
+When enabled, opening SRQuestDownloader will automatically:
+1. Check for and download any new custom maps published since your last fetch (Fetch button shows `Checking for new customs...`)
+2. After that finishes, show the result on the Fetch button (e.g. `3 new customs found`) and a 5 second countdown on **Play Synth Riders** (`Synthing: N` / `Tap to stay` on two lines)
+3. Launch Synth Riders and close this app
+
+Tap **Play Synth Riders** during the countdown to cancel the auto-launch and stay in the app. You can also turn **0-Click** off at any time. No other in-app interaction is required once the countdown finishes. Existing installs that already have a last-fetch timestamp unlock this toggle immediately.
+
 
 ---
 # More Details


### PR DESCRIPTION
Closes #19

## Summary

This implements the **zero-click "update, launch Synth"** flow requested in #19 - finally, ~2 years later, with a working Quest 3 build behind it.

I am a huge Synth Riders fan - custom maps, new releases, the whole loop. SR Quest Downloader is already part of my routine, but I wanted it to feel like **how I launch Synth Riders**: open the downloader, grab anything new since last fetch, then get into the game. No extra taps once I opt in.

After one successful manual fetch, a new **0-Click: OFF/ON** toggle appears on the bottom row. When enabled, opening the app will:

1. **Immediately check for and download** new customs since your last fetch (Fetch button shows `Checking for new customs...`)
2. **Report results** on the Fetch button (e.g. `0 new customs found`, `3 new customs found`)
3. **Count down on Play Synth Riders** (`Synthing: 5` / `Tap to stay`) - tap that same button to cancel and stay in the app
4. **Launch Synth Riders and quit** if you do not cancel within 5 seconds

This turns SR Quest Downloader into a one-shot launcher for my headset: customs stay current, then I am in Synth.

## Relation to #19

Issue #19 asked for an enable-able option where the default flow is **"update, launch synth"** with a way to cancel during launch if you need to do maintenance instead. That is exactly what this PR delivers:

| #19 idea | This PR |
|----------|---------|
| Optional auto update + launch | **0-Click: OFF/ON** toggle (unlocks after first successful fetch) |
| Cancel during launch | 5s countdown on **Play Synth Riders**; tap to stay, or turn 0-Click off |
| Zero clicks to keep songs current | Open app -> fetch -> countdown -> Synth (no Fetch/Play taps when 0-Click is on) |

## Demo

Tested on Quest 3 - demo video attached in PR comments.

## UI changes

- Bottom row is now: **Play Synth Riders** | **0-Click** | **Exit**
- 0-Click toggle is hidden until the user completes their first successful fetch
- Existing installs with a prior last-fetch timestamp unlock the toggle immediately

## Companion PR

Small SRTimestampManager change to expose how many new maps were found:

- https://github.com/bookdude13/SRTimestampManager/pull/6

## Test plan

- [x] Fresh install: manual fetch unlocks 0-Click toggle
- [x] 0-Click ON: app checks for customs immediately on launch (no pre-fetch countdown)
- [x] Fetch button updates with new-custom count after check completes
- [x] Play button shows 5-second launch countdown on two lines; tap cancels auto-launch
- [x] Countdown completes: Synth Riders launches and downloader exits
- [x] 0-Click OFF during fetch or countdown cancels the auto-launch flow
- [x] Normal manual use unchanged when 0-Click is OFF

(Supersedes closed #28 - same branch, clean timeline.)
